### PR TITLE
feat(sync): multi-list support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,12 +61,12 @@ jobs:
             type=semver,pattern={{major}}
             # Set edge tag for main branch
             type=edge,branch=main
-            # Set branch name for branches
-            type=ref,event=branch
+            # Set branch name for branches (sanitized)
+            type=ref,event=branch,suffix=-{{sha}}
             # Set PR number for pull requests
             type=ref,event=pr
-            # Set sha for commits
-            type=sha,prefix={{branch}}-,suffix=-{{date 'YYYYMMDD'}},format=short
+            # Set sha tag for commits (simplified)
+            type=sha,format=short,enable={{is_default_branch}}
           labels: |
             maintainer=${{ github.repository_owner }}
             org.opencontainers.image.title=Letterboxd to Radarr Sync

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,18 +59,12 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            # Set edge tag for main branch
-            type=edge,branch=main
             # Set branch name for branches (sanitized)
-            type=ref,event=branch,suffix=-{{sha}}
-            # Set PR number for pull requests
-            type=ref,event=pr
-            # Set sha tag for commits (simplified)
-            type=sha,format=short,enable={{is_default_branch}}
+            type=ref,event=branch
           labels: |
             maintainer=${{ github.repository_owner }}
             org.opencontainers.image.title=Letterboxd to Radarr Sync
-            org.opencontainers.image.description=Automatically sync Letterboxd watchlist to Radarr
+            org.opencontainers.image.description=Automatically sync Letterboxd lists to Radarr
             org.opencontainers.image.vendor=${{ github.repository_owner }}
 
       # Build and push Docker image

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ data
 
 # Environment file
 .env
+config.yml

--- a/README.md
+++ b/README.md
@@ -115,14 +115,7 @@ docker build -t letterboxarr .
 docker run -d \
   --name letterboxarr \
   --restart unless-stopped \
-  -e RADARR_API_KEY=your_api_key \
-  -e LETTERBOXD_USERNAME=your_letterboxd_username \
-  -e RADARR_URL=http://192.168.1.100:7878 \
-  -e RADARR_QUALITY_PROFILE=4 \
-  -e RADARR_ROOT_FOLDER=/movies \
-  -e RADARR_MONITOR_ADDED_MOVIES=true \
-  -e RADARR_START_SEARCHING_ADDED_MOVIES=true \
-  -e SYNC_INTERVAL_MINUTES=60 \
+  -v $(pwd)/config.yml:/app/config.yml \
   -v $(pwd)/data:/app/data \
   letterboxarr
 ```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # Letterboxarr : Letterboxd to Radarr Sync
 
-Automatically sync your Letterboxd watchlist to your Radarr instance. This script periodically checks your Letterboxd watchlist and adds any new movies to Radarr.
+Automatically sync your Letterboxd lists to your Radarr instance. This script periodically checks your configured Letterboxd lists and adds any new movies to Radarr.
 
 ## Features
 
-- 🎬 Scrapes Letterboxd watchlist (no API key needed)
+- 🎬 Scrapes multiple Letterboxd lists (watchlists, collections, actors, directors, etc.)
+- 🏷️ Automatic tag assignment to movies based on their source list
 - 🔄 Automatic periodic synchronization
 - 📝 Tracks processed movies to avoid duplicates
 - 🐳 Docker support for easy deployment
-- 🔍 Smart movie matching using title and year
-- ⚡ Configurable sync interval
+- 🔍 Smart movie matching using title and year, falling back to TMDB ID
+- ⚡ Configurable sync interval and filters
+- 🎭 Per-list filtering (skip documentaries, short films, etc.)
+- ⚙️ YAML configuration file support
 
 ## Prerequisites
 
@@ -44,11 +47,48 @@ curl -H "X-Api-Key: YOUR_API_KEY" http://your-radarr-url:7878/api/v3/rootfolder
 
 Note the `path` of your movies folder.
 
+### 4. Create Configuration File
+
+Copy the example configuration:
+```bash
+cp config.example.yml config.yml
+```
+
+Edit `config.yml` with your settings:
+```yaml
+sync:
+  schedule:
+    interval_minutes: 60
+
+radarr:
+  url: http://radarr:7878
+  api_key: your-api-key-here
+  quality_profile: 1
+  root_folder: /movies
+  monitor_added: true
+  search_added: true
+
+letterboxd:
+  filters:
+    skip_documentaries: false
+    skip_short_films: false
+    skip_unreleased: false
+    skip_tv_shows: true
+  watch:
+    - username/watchlist:
+        tags:
+          - watchlist
+    - films/popular
+    - actor/daniel-day-lewis
+```
+
 ## Deployment Options
 
 ### Option 1: Docker Compose (Recommended)
 
-1. Create a docker-compose.yml file with the following content:
+1. Create your `config.yml` file (see setup section above)
+
+2. Create a docker-compose.yml file:
 
 ```yaml
 ---
@@ -57,28 +97,14 @@ services:
     image: fcote/letterboxarr:latest
     container_name: letterboxarr
     restart: unless-stopped
-    environment:
-      - RADARR_API_KEY=your_radarr_api_key_here
-      - LETTERBOXD_USERNAME=your_letterboxd_username_here
-      - RADARR_URL=http://radarr:7878             # Change to your Radarr URL
-      - RADARR_QUALITY_PROFILE=1                  # Change to your preferred quality profile ID
-      - RADARR_ROOT_FOLDER=/movies                # Change to your movies folder path
-      - RADARR_MONITOR_ADDED_MOVIES=true          # Monitor added movies
-      - RADARR_START_SEARCHING_ADDED_MOVIES=true  # Start searching for added movies
-      - SYNC_INTERVAL_MINUTES=60                  # How often to check for new movies
-
     volumes:
-      - ./data:/app/data  # Persistent storage for tracking processed movies
+      - ./config.yml:/app/config.yml  # Configuration file
+      - ./data:/app/data              # Persistent storage for tracking processed movies
 ```
 
-2. Build and run:
+3. Build and run:
 ```bash
 docker-compose up -d
-```
-
-3. Check logs:
-```bash
-docker-compose logs -f
 ```
 
 ### Option 2: Docker Run
@@ -103,6 +129,22 @@ docker run -d \
 
 ### Option 3: Local Python
 
+#### With Configuration File (Recommended)
+
+1. Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+2. Create your `config.yml` file (see setup section above)
+
+3. Run the script:
+```bash
+python main.py
+```
+
+#### With Environment Variables (Legacy)
+
 1. Install dependencies:
 ```bash
 pip install -r requirements.txt
@@ -125,9 +167,60 @@ export SYNC_INTERVAL_MINUTES=60
 python main.py
 ```
 
-## Configuration
+## Configuration Reference
 
-| Environment Variable                  | Required | Default | Description                      |
+### YAML Configuration (config.yml)
+
+```yaml
+sync:
+  schedule:
+    interval_minutes: 60          # How often to check for new movies
+
+radarr:
+  url: http://radarr:7878         # Radarr instance URL
+  api_key: your-api-key           # Your Radarr API key (required)
+  quality_profile: 1              # Quality profile ID to use
+  root_folder: /movies            # Root folder path for movies
+  monitor_added: true             # Monitor newly added movies
+  search_added: true              # Start searching for newly added movies
+
+letterboxd:
+  filters:                        # Global filters (can be overridden per-list)
+    skip_documentaries: false     # Skip documentary films
+    skip_short_films: false       # Skip short films
+    skip_unreleased: false        # Skip unreleased films
+    skip_tv_shows: true           # Skip TV shows/series
+  
+  watch:                          # List of Letterboxd pages to monitor
+    - username/watchlist          # Simple watchlist
+    - username/watchlist:         # Watchlist with custom settings
+        filters:
+          skip_documentaries: true
+        tags:
+          - watchlist
+    - films/popular               # Popular films
+    - actor/daniel-day-lewis      # Actor filmography
+    - director/david-fincher      # Director filmography
+```
+
+### Supported Letterboxd List Types
+
+- **User Lists**: `username/watchlist`, `username/films`, `username/diary`
+- **Collections**: `films/in/collection-name`
+- **Popular/Charts**: `films/popular`, `films/popular/this/year`
+- **People**: `actor/name`, `director/name`, `writer/name`
+- **Genres**: `films/genre/horror`, `films/genre/sci-fi`
+- **Custom Lists**: Any valid Letterboxd URL path
+
+### Tags and Filtering
+
+Movies from each list can be automatically tagged in Radarr. Filters can be applied globally or per-list to skip certain types of content.
+
+### Legacy Environment Variables
+
+For backwards compatibility, the following environment variables are still supported:
+
+| Variable                              | Required | Default | Description                      |
 |---------------------------------------|----------|---------|----------------------------------|
 | `RADARR_API_KEY`                      | Yes      | -       | Your Radarr API key              |
 | `LETTERBOXD_USERNAME`                 | Yes      | -       | Letterboxd username to sync      |

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,58 @@
+# Letterboxarr Configuration File
+# Copy this to config.yml and customize for your setup
+
+---
+sync:
+  schedule:
+    interval_minutes: 60  # How often to check for new movies (in minutes)
+
+radarr:
+  url: http://radarr:7878      # Radarr instance URL
+  api_key: your-api-key-here   # Radarr API key (required)
+  quality_profile: 1           # Quality profile ID to use for added movies
+  root_folder: /movies         # Root folder path for movies
+  monitor_added: true          # Whether to monitor newly added movies
+  search_added: true           # Whether to start searching for newly added movies
+
+letterboxd:
+  filters:
+    # Global filters applied to all lists (can be overridden per-list)
+    skip_documentaries: false    # Skip documentary films
+    skip_short_films: false      # Skip short films
+    skip_unreleased: false       # Skip unreleased films
+    skip_tv_shows: true          # Skip TV shows/series
+  
+  watch:
+    # List of Letterboxd pages to monitor for movies
+    # Each item can be a simple string or a dictionary with filters/tags
+    
+    # Simple watchlist
+    - username/watchlist
+    
+    # Watchlist with custom filters and tags
+    - username/watchlist:
+        filters:                     # Override global filters for this list
+          skip_documentaries: true
+          skip_short_films: true
+        tags:                        # Tags to add to movies from this list
+          - watchlist
+          - high-priority
+    
+    # Collections, popular lists, etc.
+    - films/in/the-godfather-collection
+    - films/popular/this/year
+    - films/popular/this/decade
+    
+    # Actor, director, writer pages
+    - actor/daniel-day-lewis
+    - director/david-fincher
+    - writer/aaron-sorkin
+          
+# Filter cookie format reference:
+# Letterboxd uses these filter names in cookies:
+# - hide-shorts: Skip short films
+# - hide-tv: Skip TV shows
+# - hide-docs: Skip documentaries  
+# - hide-unreleased: Skip unreleased films
+# 
+# These are automatically converted from the filter settings above

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -4,15 +4,6 @@ services:
     image: fcote/letterboxarr:latest
     container_name: letterboxarr
     restart: unless-stopped
-    environment:
-      - RADARR_API_KEY=your_radarr_api_key_here
-      - LETTERBOXD_USERNAME=your_letterboxd_username_here
-      - RADARR_URL=http://radarr:7878             # Change to your Radarr URL
-      - RADARR_QUALITY_PROFILE=1                  # Change to your preferred quality profile ID
-      - RADARR_ROOT_FOLDER=/movies                # Change to your movies folder path
-      - RADARR_MONITOR_ADDED_MOVIES=true          # Monitor added movies
-      - RADARR_START_SEARCHING_ADDED_MOVIES=true  # Start searching for added movies
-      - SYNC_INTERVAL_MINUTES=60                  # How often to check for new movies
-
     volumes:
-      - ./data:/app/data  # Persistent storage for tracking processed movies
+      - ./config.yml:/app/config.yml  # Configuration file
+      - ./data:/app/data              # Persistent storage for tracking processed movies

--- a/lib_config.py
+++ b/lib_config.py
@@ -1,0 +1,183 @@
+"""Configuration handling for letterboxarr"""
+
+import os
+import yaml
+from typing import Dict, List, Optional, Any
+from dataclasses import dataclass
+
+
+@dataclass
+class SyncConfig:
+    """Sync configuration"""
+    interval_minutes: int = 60
+
+
+@dataclass
+class RadarrConfig:
+    """Radarr configuration"""
+    url: str
+    api_key: str
+    quality_profile: int
+    root_folder: str
+    monitor_added: bool = True
+    search_added: bool = True
+
+
+@dataclass
+class LetterboxdFilters:
+    """Letterboxd filter configuration"""
+    skip_documentaries: bool = False
+    skip_short_films: bool = False
+    skip_unreleased: bool = False
+    skip_tv_shows: bool = True
+
+
+@dataclass
+class WatchListItem:
+    """Individual watch list item configuration"""
+    path: str
+    filters: Optional[LetterboxdFilters] = None
+    tags: List[str] = None
+    
+    def __post_init__(self):
+        if self.tags is None:
+            self.tags = []
+
+
+@dataclass
+class LetterboxdConfig:
+    """Letterboxd configuration"""
+    filters: LetterboxdFilters
+    watch: List[WatchListItem]
+
+
+@dataclass
+class Config:
+    """Main configuration object"""
+    sync: SyncConfig
+    radarr: RadarrConfig
+    letterboxd: LetterboxdConfig
+
+
+class ConfigLoader:
+    """Configuration loader and validator"""
+    
+    @staticmethod
+    def load_config(config_path: str = "config.yml") -> Config:
+        """Load configuration from YAML file"""
+        if not os.path.exists(config_path):
+            raise FileNotFoundError(f"Configuration file not found: {config_path}")
+        
+        with open(config_path, 'r') as f:
+            config_data = yaml.safe_load(f)
+        
+        # Validate required sections
+        required_sections = ['sync', 'radarr', 'letterboxd']
+        for section in required_sections:
+            if section not in config_data:
+                raise ValueError(f"Required configuration section missing: {section}")
+        
+        # Parse sync config
+        sync_data = config_data['sync']
+        sync_config = SyncConfig(
+            interval_minutes=sync_data.get('schedule', {}).get('interval_minutes', 60)
+        )
+        
+        # Parse radarr config
+        radarr_data = config_data['radarr']
+        radarr_config = RadarrConfig(
+            url=radarr_data['url'],
+            api_key=radarr_data['api_key'],
+            quality_profile=radarr_data['quality_profile'],
+            root_folder=radarr_data['root_folder'],
+            monitor_added=radarr_data.get('monitor_added', True),
+            search_added=radarr_data.get('search_added', True)
+        )
+        
+        # Parse letterboxd config
+        letterboxd_data = config_data['letterboxd']
+        
+        # Parse global filters
+        filters_data = letterboxd_data.get('filters', {})
+        global_filters = LetterboxdFilters(
+            skip_documentaries=filters_data.get('skip_documentaries', False),
+            skip_short_films=filters_data.get('skip_short_films', False),
+            skip_unreleased=filters_data.get('skip_unreleased', False),
+            skip_tv_shows=filters_data.get('skip_tv_shows', True)
+        )
+        
+        # Parse watch list
+        watch_list = []
+        for watch_item in letterboxd_data.get('watch', []):
+            if isinstance(watch_item, str):
+                # Simple string format
+                watch_list.append(WatchListItem(path=watch_item))
+            elif isinstance(watch_item, dict):
+                # Dictionary format with filters/tags
+                for path, config in watch_item.items():
+                    item_filters = None
+                    if 'filters' in config:
+                        filter_data = config['filters']
+                        item_filters = LetterboxdFilters(
+                            skip_documentaries=filter_data.get('skip_documentaries', global_filters.skip_documentaries),
+                            skip_short_films=filter_data.get('skip_short_films', global_filters.skip_short_films),
+                            skip_unreleased=filter_data.get('skip_unreleased', global_filters.skip_unreleased),
+                            skip_tv_shows=filter_data.get('skip_tv_shows', global_filters.skip_tv_shows)
+                        )
+                    
+                    tags = config.get('tags', [])
+                    watch_list.append(WatchListItem(
+                        path=path,
+                        filters=item_filters,
+                        tags=tags
+                    ))
+        
+        letterboxd_config = LetterboxdConfig(
+            filters=global_filters,
+            watch=watch_list
+        )
+        
+        return Config(
+            sync=sync_config,
+            radarr=radarr_config,
+            letterboxd=letterboxd_config
+        )
+    
+    @staticmethod
+    def validate_config(config: Config) -> List[str]:
+        """Validate configuration and return list of errors"""
+        errors = []
+        
+        # Validate radarr config
+        if not config.radarr.url:
+            errors.append("Radarr URL is required")
+        if not config.radarr.api_key:
+            errors.append("Radarr API key is required")
+        if not config.radarr.root_folder:
+            errors.append("Radarr root folder is required")
+        
+        # Validate letterboxd config
+        if not config.letterboxd.watch:
+            errors.append("At least one Letterboxd watch item is required")
+        
+        # Validate sync config
+        if config.sync.interval_minutes <= 0:
+            errors.append("Sync interval must be greater than 0")
+        
+        return errors
+
+
+def create_letterboxd_cookie_filters(filters: LetterboxdFilters) -> str:
+    """Convert filter configuration to Letterboxd cookie format"""
+    cookie_parts = []
+    
+    if filters.skip_short_films:
+        cookie_parts.append("hide-shorts")
+    if filters.skip_tv_shows:
+        cookie_parts.append("hide-tv")
+    if filters.skip_documentaries:
+        cookie_parts.append("hide-docs")
+    if filters.skip_unreleased:
+        cookie_parts.append("hide-unreleased")
+    
+    return "%20".join(cookie_parts)

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ Letterboxd to Radarr Watchlist Sync
 Monitors Letterboxd lists and imports movies to Radarr
 """
 
-import os
 import sys
 import logging
 from pathlib import Path

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ import logging
 from pathlib import Path
 
 from lib_sync import LetterboxdRadarrSync
-from lib_config import ConfigLoader, Config, SyncConfig, RadarrConfig, LetterboxdConfig, LetterboxdFilters, WatchListItem
+from lib_config import ConfigLoader, load_config_from_env
 
 # Configure logging
 logging.basicConfig(
@@ -18,69 +18,6 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
-
-
-def load_config_from_env():
-    """Load configuration from environment variables (legacy support)"""
-    logger.info("Loading configuration from environment variables (legacy mode)")
-    
-    # Required environment variables
-    radarr_api_key = os.getenv('RADARR_API_KEY')
-    radarr_url = os.getenv('RADARR_URL')
-    quality_profile = os.getenv('RADARR_QUALITY_PROFILE')
-    letterboxd_user = os.getenv('LETTERBOXD_USERNAME')
-    
-    # Check required variables
-    missing_vars = []
-    if not radarr_api_key:
-        missing_vars.append('RADARR_API_KEY')
-    if not radarr_url:
-        missing_vars.append('RADARR_URL')
-    if not quality_profile:
-        missing_vars.append('RADARR_QUALITY_PROFILE')
-    if not letterboxd_user:
-        missing_vars.append('LETTERBOXD_USERNAME')
-    
-    if missing_vars:
-        logger.error("Missing required environment variables:")
-        for var in missing_vars:
-            logger.error(f"  - {var}")
-        sys.exit(1)
-    
-    # Create config from environment variables
-    sync_config = SyncConfig(
-        interval_minutes=int(os.getenv('SYNC_INTERVAL_MINUTES', '60'))
-    )
-    
-    radarr_config = RadarrConfig(
-        url=radarr_url,
-        api_key=radarr_api_key,
-        quality_profile=int(quality_profile),
-        root_folder=os.getenv('RADARR_ROOT_FOLDER', '/movies'),
-        monitor_added=os.getenv('RADARR_MONITOR_ADDED_MOVIES', 'true').lower() == 'true',
-        search_added=os.getenv('RADARR_START_SEARCHING_ADDED_MOVIES', 'true').lower() == 'true'
-    )
-    
-    letterboxd_filters = LetterboxdFilters(
-        skip_documentaries=False,
-        skip_short_films=False,
-        skip_unreleased=False,
-        skip_tv_shows=True
-    )
-    
-    # Create simple watchlist from username
-    watch_items = [WatchListItem(path=f"{letterboxd_user}/watchlist")]
-    
-    letterboxd_config = LetterboxdConfig(
-        filters=letterboxd_filters,
-        watch=watch_items
-    )
-    
-    return Config(
-        sync=sync_config,
-        radarr=radarr_config,
-        letterboxd=letterboxd_config
-    )
 
 
 def main():
@@ -110,7 +47,7 @@ def main():
         # Fall back to environment variables
         logger.warning(f"Configuration file {config_path} not found, trying environment variables...")
         try:
-            config = load_config_from_env()
+            config = load_config_from_env(logger)
         except Exception as e:
             logger.error(f"Error loading configuration from environment: {e}")
             logger.error("Please create a config.yml file or set the required environment variables")

--- a/main.py
+++ b/main.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 """
 Letterboxd to Radarr Watchlist Sync
-Monitors a Letterboxd watchlist and imports movies to Radarr
+Monitors Letterboxd lists and imports movies to Radarr
 """
 
 import os
+import sys
 import logging
+from pathlib import Path
 
 from lib_sync import LetterboxdRadarrSync
+from lib_config import ConfigLoader, Config, SyncConfig, RadarrConfig, LetterboxdConfig, LetterboxdFilters, WatchListItem
 
 # Configure logging
 logging.basicConfig(
@@ -17,56 +20,118 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def main():
-    """Main entry point"""
-    # Get configuration from environment variables
-    letterboxd_user = os.getenv('LETTERBOXD_USERNAME')
-    radarr_url = os.getenv('RADARR_URL')
+def load_config_from_env():
+    """Load configuration from environment variables (legacy support)"""
+    logger.info("Loading configuration from environment variables (legacy mode)")
+    
+    # Required environment variables
     radarr_api_key = os.getenv('RADARR_API_KEY')
-    quality_profile = int(os.getenv('RADARR_QUALITY_PROFILE'))
-    root_folder = os.getenv('RADARR_ROOT_FOLDER')
-    monitor_movies = os.getenv('RADARR_MONITOR_ADDED_MOVIES', 'true').lower() == 'true'
-    search_movies = os.getenv('RADARR_START_SEARCHING_ADDED_MOVIES', 'true').lower() == 'true'
-    sync_interval = int(os.getenv('SYNC_INTERVAL_MINUTES', '60'))
-
+    radarr_url = os.getenv('RADARR_URL')
+    quality_profile = os.getenv('RADARR_QUALITY_PROFILE')
+    letterboxd_user = os.getenv('LETTERBOXD_USERNAME')
+    
+    # Check required variables
+    missing_vars = []
     if not radarr_api_key:
-        logger.error("RADARR_API_KEY environment variable is required")
-        exit(1)
-
-    if not letterboxd_user:
-        logger.error("LETTERBOXD_USERNAME environment variable is required")
-        exit(1)
-
+        missing_vars.append('RADARR_API_KEY')
     if not radarr_url:
-        logger.error("RADARR_URL environment variable is required")
-        exit(1)
-
+        missing_vars.append('RADARR_URL')
     if not quality_profile:
-        logger.error("RADARR_QUALITY_PROFILE environment variable is required")
-        exit(1)
-
-    # Create sync instance
-    sync = LetterboxdRadarrSync(
-        logger=logger,
-        letterboxd_username=letterboxd_user,
-        radarr_url=radarr_url,
-        radarr_api_key=radarr_api_key,
-        quality_profile=quality_profile,
-        root_folder=root_folder,
-        monitor_movies=monitor_movies,
-        search_movies=search_movies
+        missing_vars.append('RADARR_QUALITY_PROFILE')
+    if not letterboxd_user:
+        missing_vars.append('LETTERBOXD_USERNAME')
+    
+    if missing_vars:
+        logger.error("Missing required environment variables:")
+        for var in missing_vars:
+            logger.error(f"  - {var}")
+        sys.exit(1)
+    
+    # Create config from environment variables
+    sync_config = SyncConfig(
+        interval_minutes=int(os.getenv('SYNC_INTERVAL_MINUTES', '60'))
+    )
+    
+    radarr_config = RadarrConfig(
+        url=radarr_url,
+        api_key=radarr_api_key,
+        quality_profile=int(quality_profile),
+        root_folder=os.getenv('RADARR_ROOT_FOLDER', '/movies'),
+        monitor_added=os.getenv('RADARR_MONITOR_ADDED_MOVIES', 'true').lower() == 'true',
+        search_added=os.getenv('RADARR_START_SEARCHING_ADDED_MOVIES', 'true').lower() == 'true'
+    )
+    
+    letterboxd_filters = LetterboxdFilters(
+        skip_documentaries=False,
+        skip_short_films=False,
+        skip_unreleased=False,
+        skip_tv_shows=True
+    )
+    
+    # Create simple watchlist from username
+    watch_items = [WatchListItem(path=f"{letterboxd_user}/watchlist")]
+    
+    letterboxd_config = LetterboxdConfig(
+        filters=letterboxd_filters,
+        watch=watch_items
+    )
+    
+    return Config(
+        sync=sync_config,
+        radarr=radarr_config,
+        letterboxd=letterboxd_config
     )
 
+
+def main():
+    """Main entry point"""
+    config_path = "config.yml"
+    
+    # Try to load from the config file first, then fall back to environment variables
+    if Path(config_path).exists():
+        try:
+            # Load configuration from YAML file
+            config = ConfigLoader.load_config(config_path)
+            
+            # Validate configuration
+            validation_errors = ConfigLoader.validate_config(config)
+            if validation_errors:
+                logger.error("Configuration validation failed:")
+                for error in validation_errors:
+                    logger.error(f"  - {error}")
+                sys.exit(1)
+            
+            logger.info("Configuration loaded from config.yml")
+
+        except Exception as e:
+            logger.error(f"Error loading configuration file: {e}")
+            sys.exit(1)
+    else:
+        # Fall back to environment variables
+        logger.warning(f"Configuration file {config_path} not found, trying environment variables...")
+        try:
+            config = load_config_from_env()
+        except Exception as e:
+            logger.error(f"Error loading configuration from environment: {e}")
+            logger.error("Please create a config.yml file or set the required environment variables")
+            sys.exit(1)
+
+    # Create sync instance
+    sync = LetterboxdRadarrSync(logger=logger, config=config)
+
     # Log configuration
-    logger.info("Configuration:")
-    logger.info(f"  Letterboxd User: {letterboxd_user}")
-    logger.info(f"  Radarr URL: {radarr_url}")
-    logger.info(f"  Quality Profile: {quality_profile}")
-    logger.info(f"  Root Folder: {root_folder}")
-    logger.info(f"  Sync Interval: {sync_interval} minutes")
+    logger.info("Configuration loaded successfully:")
+    logger.info(f"  Radarr URL: {config.radarr.url}")
+    logger.info(f"  Quality Profile: {config.radarr.quality_profile}")
+    logger.info(f"  Root Folder: {config.radarr.root_folder}")
+    logger.info(f"  Sync Interval: {config.sync.interval_minutes} minutes")
+    logger.info(f"  Watch Lists: {len(config.letterboxd.watch)} configured")
+    
+    for i, watch_item in enumerate(config.letterboxd.watch):
+        logger.info(f"    {i+1}. {watch_item.path} (tags: {watch_item.tags})")
 
     # Run continuous sync
-    sync.run_continuous(sync_interval)
+    sync.run_continuous(config.sync.interval_minutes)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,6 @@ description = "Automatically sync your Letterboxd watchlist to your Radarr insta
 requires-python = ">=3.9"
 dependencies = [
     "requests==2.31.0",
-    "beautifulsoup4==4.12.2"
+    "beautifulsoup4==4.12.2",
+    "pyyaml==6.0.1"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.31.0
 beautifulsoup4==4.12.2
+pyyaml==6.0.1


### PR DESCRIPTION
- Add YAML configuration system with validation and backwards compatibility
- Support multiple Letterboxd list types (watchlists, collections, actors, directors, etc.)
- Implement per-list filtering and automatic tag assignment to Radarr
- Add Letterboxd cookie-based filtering (hide docs/shorts/tv/unreleased)
- Create migration script for converting from environment variables
- Maintain full backwards compatibility with existing env var setups
- Add comprehensive documentation and example configuration
- Dependencies: add pyyaml==6.0